### PR TITLE
フォーム作成（リセット、valicator）

### DIFF
--- a/lib/function_20221006/weather_forecast_repository.dart
+++ b/lib/function_20221006/weather_forecast_repository.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class WeatherForecastRepository {
+  static Future<void> fetchWeather(String city) async {
+    final url =
+        Uri.parse('https://weather.tsukumijima.net/api/forecast?city=$city');
+    final response = await http.get(url);
+    if (response.statusCode == 200) {
+      final String results =
+          const Utf8Decoder(allowMalformed: true).convert(response.bodyBytes);
+      print(results);
+    } else {
+      throw Exception('Request failed with status: ${response.statusCode}.');
+    }
+  }
+}

--- a/lib/function_20221006/weather_forecasts_form_page.dart
+++ b/lib/function_20221006/weather_forecasts_form_page.dart
@@ -9,7 +9,10 @@ class WeatherForecastsFormPage extends StatefulWidget {
 }
 
 class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
+  final _formKey = GlobalKey<FormState>();
   TextEditingController _controller = TextEditingController();
+  final String message = '地域ID（6ケタの数字）を入力してください。';
+  final String pattern = r'^[0-9]{6}$';
 
   void _clearText() {
     setState(() {
@@ -17,42 +20,60 @@ class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
     });
   }
 
+  void submit() {
+    if (_formKey.currentState!.validate()) {
+      print('success');
+    } else {
+      print('faild');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 64.0, horizontal: 16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const Expanded(
-                child: Center(
-                  child: Text('結果を表示'),
+    return Form(
+      key: _formKey,
+      child: Scaffold(
+        body: SafeArea(
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(vertical: 64.0, horizontal: 16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Expanded(
+                  child: Center(
+                    child: Text('結果を表示'),
+                  ),
                 ),
-              ),
-              const Text('地域ID（6ケタの数字）を入力してください。'),
-              TextFormField(
-                controller: _controller,
-              ),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextButton(
-                      onPressed: _clearText,
-                      child: const Text('クリア'),
+                Text(message),
+                TextFormField(
+                  controller: _controller,
+                  validator: (value) {
+                    if (!RegExp(pattern).hasMatch(value!)) {
+                      return message;
+                    }
+                    return null;
+                  },
+                ),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextButton(
+                        onPressed: _clearText,
+                        child: const Text('クリア'),
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 16.0),
-                  Expanded(
-                    child: TextButton(
-                      onPressed: () {},
-                      child: const Text('送信'),
+                    const SizedBox(width: 16.0),
+                    Expanded(
+                      child: TextButton(
+                        onPressed: submit,
+                        child: const Text('送信'),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/function_20221006/weather_forecasts_form_page.dart
+++ b/lib/function_20221006/weather_forecasts_form_page.dart
@@ -1,7 +1,5 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
+import 'package:weekly_trace_challenge/function_20221006/weather_forecast_repository.dart';
 
 class WeatherForecastsFormPage extends StatefulWidget {
   const WeatherForecastsFormPage({Key? key}) : super(key: key);
@@ -22,22 +20,9 @@ class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
     });
   }
 
-  Future<void> fetchWeather() async {
-    final url = Uri.parse(
-        'https://weather.tsukumijima.net/api/forecast?city=${_controller.text}');
-    final response = await http.get(url);
-    if (response.statusCode == 200) {
-      final String results =
-          const Utf8Decoder(allowMalformed: true).convert(response.bodyBytes);
-      print(results);
-    } else {
-      throw Exception('Request failed with status: ${response.statusCode}.');
-    }
-  }
-
   void submit() {
     if (_formKey.currentState!.validate()) {
-      fetchWeather();
+      WeatherForecastRepository.fetchWeather(_controller.text);
     }
   }
 

--- a/lib/function_20221006/weather_forecasts_form_page.dart
+++ b/lib/function_20221006/weather_forecasts_form_page.dart
@@ -1,7 +1,21 @@
 import 'package:flutter/material.dart';
 
-class WeatherForecastsFormPage extends StatelessWidget {
+class WeatherForecastsFormPage extends StatefulWidget {
   const WeatherForecastsFormPage({Key? key}) : super(key: key);
+
+  @override
+  State<WeatherForecastsFormPage> createState() =>
+      _WeatherForecastsFormPageState();
+}
+
+class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
+  TextEditingController _controller = TextEditingController();
+
+  void _clearText() {
+    setState(() {
+      _controller = TextEditingController();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,12 +32,14 @@ class WeatherForecastsFormPage extends StatelessWidget {
                 ),
               ),
               const Text('地域ID（6ケタの数字）を入力してください。'),
-              TextFormField(),
+              TextFormField(
+                controller: _controller,
+              ),
               Row(
                 children: [
                   Expanded(
                     child: TextButton(
-                      onPressed: () {},
+                      onPressed: _clearText,
                       child: const Text('クリア'),
                     ),
                   ),

--- a/lib/function_20221006/weather_forecasts_form_page.dart
+++ b/lib/function_20221006/weather_forecasts_form_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 class WeatherForecastsFormPage extends StatefulWidget {
   const WeatherForecastsFormPage({Key? key}) : super(key: key);
@@ -20,11 +21,20 @@ class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
     });
   }
 
+  Future<void> fetchWeather() async {
+    final url = Uri.parse(
+        'https://weather.tsukumijima.net/api/forecast?city=${_controller.text}');
+    final response = await http.get(url);
+    if (response.statusCode == 200) {
+      print(response.body);
+    } else {
+      print('Request failed with status: ${response.statusCode}.');
+    }
+  }
+
   void submit() {
     if (_formKey.currentState!.validate()) {
-      print('success');
-    } else {
-      print('faild');
+      fetchWeather();
     }
   }
 

--- a/lib/function_20221006/weather_forecasts_form_page.dart
+++ b/lib/function_20221006/weather_forecasts_form_page.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class WeatherForecastsFormPage extends StatelessWidget {
+  const WeatherForecastsFormPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 64.0, horizontal: 16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Expanded(
+                child: Center(
+                  child: Text('結果を表示'),
+                ),
+              ),
+              const Text('地域ID（6ケタの数字）を入力してください。'),
+              TextFormField(),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextButton(
+                      onPressed: () {},
+                      child: const Text('クリア'),
+                    ),
+                  ),
+                  const SizedBox(width: 16.0),
+                  Expanded(
+                    child: TextButton(
+                      onPressed: () {},
+                      child: const Text('送信'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/function_20221006/weather_forecasts_form_page.dart
+++ b/lib/function_20221006/weather_forecasts_form_page.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
@@ -13,7 +15,6 @@ class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
   final _formKey = GlobalKey<FormState>();
   TextEditingController _controller = TextEditingController();
   final String message = '地域ID（6ケタの数字）を入力してください。';
-  final String pattern = r'^[0-9]{6}$';
 
   void _clearText() {
     setState(() {
@@ -26,9 +27,11 @@ class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
         'https://weather.tsukumijima.net/api/forecast?city=${_controller.text}');
     final response = await http.get(url);
     if (response.statusCode == 200) {
-      print(response.body);
+      final String results =
+          const Utf8Decoder(allowMalformed: true).convert(response.bodyBytes);
+      print(results);
     } else {
-      print('Request failed with status: ${response.statusCode}.');
+      throw Exception('Request failed with status: ${response.statusCode}.');
     }
   }
 
@@ -52,13 +55,17 @@ class _WeatherForecastsFormPageState extends State<WeatherForecastsFormPage> {
               children: [
                 const Expanded(
                   child: Center(
-                    child: Text('結果を表示'),
+                    child: Text(
+                      '各拠点の地域ID\n東京: 130010\n長野: 200020\n岡山: 330010\n広島: 340010\n',
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                 ),
                 Text(message),
                 TextFormField(
                   controller: _controller,
                   validator: (value) {
+                    const String pattern = r'^[0-9]{6}$';
                     if (!RegExp(pattern).hasMatch(value!)) {
                       return message;
                     }

--- a/lib/top_page/trace_item_list_view.dart
+++ b/lib/top_page/trace_item_list_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:weekly_trace_challenge/function_20221006/weather_forecasts_form_page.dart';
 import 'package:weekly_trace_challenge/top_page/trace.dart';
 import 'package:weekly_trace_challenge/top_page/trace_item_tile.dart';
 
@@ -26,9 +27,9 @@ class TraceItemListView extends StatelessWidget {
 
   static const List<Trace> _functionTraces = [
     Trace(
-      title: '○○',
-      date: '2000/01/01',
-      page: Scaffold(),
+      title: 'フォーム作成（Form、正規表現）',
+      date: '2022/10/06',
+      page: WeatherForecastsFormPage(),
     ),
     Trace(
       title: '○○',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,6 +74,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.5"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   lints:
     dependency: transitive
     description:
@@ -156,6 +170,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  http: ^0.13.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 実装したこと
- 正規表現で数字6文字かどうか判定
- クリアボタンをタップでテキストを削除
- 送信ボタンタップで天気予報APIにリクエスト送信

## 実装しなかったこと
 - APIのレスポンスをUIに反映

## UI
<img width="1440" alt="スクリーンショット 2022-10-06 22 11 00" src="https://user-images.githubusercontent.com/82624334/194323480-c10ab96c-078b-4219-8a00-40b7fa304df8.png">

## 参考
 - https://weather.tsukumijima.net/#:~:text=Json%20Data%20Sample-,About,%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E7%B5%82%E4%BA%86%E3%81%A8%E3%81%AA%E3%82%8A%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82
 - https://docs.flutter.dev/cookbook/networking/fetch-data
 - https://ja.stackoverflow.com/questions/73523/ios%E3%81%A7flutter%E3%81%AEutf-8%E3%82%92decode%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84%E5%95%8F%E9%A1%8C%E3%81%AE%E8%A7%A3%E6%B1%BA%E6%96%B9%E6%B3%95